### PR TITLE
M2K test jig: Fix libiio version and add a poweroff button.

### DIFF
--- a/pluto-m2k/config/m2k/jig_pins_config
+++ b/pluto-m2k/config/m2k/jig_pins_config
@@ -1,6 +1,16 @@
 START_BUTTON=pin1
+REBOOT_BUTTON="pin7"
 
 PASSED_LED=pin3
 FAILED_LED=pin4
 READY_LED=pin5
 PROGRESS_LED=pin2
+
+__check_and_reboot() {
+	local logfile=$1
+	if grep -q "Button pressed 0x80" $logfile ; then
+		shutdown now
+		return 0
+	fi
+	return 1
+}

--- a/pluto-m2k/setup_env.sh
+++ b/pluto-m2k/setup_env.sh
@@ -162,14 +162,19 @@ __download_github_common() {
 setup_libiio() {
 	[ ! -d "work/libiio" ] || return 0
 
-	__download_github_common libiio
+	#__download_github_common libiio
+	git clone https://github.com/analogdevicesinc/libiio work/libiio
 
 	pushd work/libiio
+	git checkout 52e6dc3
 	mkdir -p build
 	pushd build
 
-	cmake ..
+	cmake -DHAVE_DNS_SD=OFF -DHAVE_AVAHI=OFF ..
 	make -j3
+	# TEMP: the install is needed to replace the iiod
+	# the system iiod uses DNS SD; the new installed version will disable the DNS SD
+	sudo make install
 
 	popd
 	popd


### PR DESCRIPTION
- The DNS SD is disabled for the ADALM2000 test jigs setup due to a delay in USB automount while ethernet or wifi are enabled.
- Locked the libiio version to 52e6dc3 for now.
- Add a poweroff button for the jig ( to shutdown the PI without any harm)